### PR TITLE
Improve Governance and Clarity for admin-pulse-bos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.0] - 2024-11-20
+
+### Added
+- Integrated **Sovereign AI-Driven Asset Allocation** into the Gateway Engine and UI.
+- Implemented **Universal Bitcoin Identity (UBI)** via RGB/Taproot and BitVM proofs.
+- Launched **Global Liquidity Mesh** for cross-chain atomic swap orchestration.
+- Added **Nexus Glass Node** state synchronization for real-time telemetry.
+- Established **Earthy Corporate Finance** theme (Forest Green/Gold) across all UI platforms.
+- Introduced **Admin Dashboard** for institutional system monitoring.
+- Created `admin-pulse-bos` service for Fiscal Orchestration (SFO).
+
+### Fixed
+- Resolved Phase 5 implementation drift for Fiat routing and A2P OTP messaging.
+- Sanitized repository root, moving maintenance scripts to `scripts/maintenance/`.
+- Standardized monorepo governance with `SECURITY.md`, `CONTRIBUTING.md`, and `CODEOWNERS`.
+
+### Improved
+- Unified system telemetry under a single `/api/v1/status` endpoint.
+- Enhanced `conxian-ui` core API client with strict typing and resilient skeleton loaders.
+- Updated root `.gitignore` to cover all monorepo service artifacts.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,6 +7,7 @@
 /services/conxian-ui/ @conxian/ui-devs
 /services/lib-conxian-core/ @conxian/core-devs
 /services/admin-dashboard/ @conxian/admin-devs
+/services/admin-pulse-bos/ @conxian/admin-devs
 
 # Documentation and Specifications
 /openspec/ @conxian/core-devs

--- a/services/admin-pulse-bos/README.md
+++ b/services/admin-pulse-bos/README.md
@@ -1,0 +1,31 @@
+# Admin Pulse (BOS)
+
+The `admin-pulse-bos` service provides administrative components for the Conxian ecosystem, focusing on fiscal orchestration and symmetry management.
+
+## 🏛️ Sovereign Financial Office (SFO)
+
+The core component, `SovereignFinancialOffice.tsx`, is a command pulse for:
+- **SFO (Sovereign Financial Office)**: Primary fiscal orchestrator.
+- **SBC (Sovereign Business Cells)**: Managing individual business unit statuses (e.g., Conxian-Core, Nexus-Labs).
+- **SYI (Sovereign Yield Index)**: Tracking and harvesting yields across the ecosystem.
+
+## 🚀 Usage
+
+This service is intended to be integrated into the Conxian administrative portal.
+
+### Development
+
+```bash
+# Navigate to the service directory
+cd services/admin-pulse-bos
+
+# Install dependencies (managed via root pnpm)
+pnpm install
+
+# Run component-specific tests or linting (if configured)
+pnpm lint
+```
+
+## 🎨 Theme
+
+Aligned with the **Earthy Corporate Finance** design language, utilizing a high-contrast dark mode aesthetic with Forest Green and Gold accents.


### PR DESCRIPTION
This PR improves the governance and public-facing clarity of the Conxian monorepo by adding a root-level CHANGELOG.md, a service-specific README for admin-pulse-bos, and updating the CODEOWNERS file. It also captures the current state of Phase 5/6 development in the changelog for better release/versioning discipline.

---
*PR created automatically by Jules for task [9496924020310810529](https://jules.google.com/task/9496924020310810529) started by @botshelomokoka*