### PR TITLE
Implement API Key Authentication for Admin Dashboard Secrets

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -22,6 +22,7 @@ CORE_BITCOIN_NETWORK=testnet
 # --- Frontend (UI & Admin) ---
 UI_PORT=3000
 ADMIN_PORT=3001
+ADMIN_DASHBOARD_API_KEY=
 NEXT_PUBLIC_CORE_API_URL=http://localhost:8080
 
 # --- Sovereign Node Services ---

--- a/services/admin-dashboard/.env.admin.example
+++ b/services/admin-dashboard/.env.admin.example
@@ -2,6 +2,10 @@
 # COPY THIS FILE TO .env.admin AND FILL IN THE ACTUAL VALUES
 # NEVER COMMIT .env.admin TO GIT
 
+# Admin Dashboard Management API Key (Used to authorize secret updates via the UI)
+# Generate a secure key: openssl rand -hex 32
+ADMIN_DASHBOARD_API_KEY='your_management_api_key'
+
 # GitHub Personal Access Token (for automated repository management)
 ADMIN_PAT_TOKEN='your_github_pat_token'
 

--- a/services/admin-dashboard/README.md
+++ b/services/admin-dashboard/README.md
@@ -7,7 +7,7 @@ This service is the internal backend/frontend orchestration layer for the Conxia
 **This dashboard is for internal, local, or high-privilege administrative use only.**
 
 - **Secret Exposure**: The `/settings` page allows viewing and modifying institutional secrets (NPM, GCP, GitHub, etc.).
-- **Access Control**: Currently intended for internal, local-only use. DO NOT expose this service to the public internet without implementing a robust authentication layer (e.g., VPN, mTLS, or RBAC).
+- **Access Control**: The management API requires a valid `ADMIN_DASHBOARD_API_KEY` for writing secrets. This should be used in conjunction with network-level isolation (e.g., VPN, mTLS) and local-only access where possible.
 - **Environment Hygiene**: Use `.env.admin` for local development ONLY. This file is intentionally ignored by Git to prevent accidental leakage of institutional credentials.
 - **Next.js Env Exposure**: Never store institutional secrets in `NEXT_PUBLIC_*` env vars and never read secrets from client-side code. Keep secret access server-side only (Route Handlers / Server Components).
 
@@ -49,7 +49,11 @@ To maintain the security of this platform:
     ```bash
     cp .env.admin.example .env.admin
     chmod 600 .env.admin  # macOS/Linux only; on Windows, restrict access via file properties or icacls
-    # Edit .env.admin with actual values (DO NOT COMMIT)
+
+    # Generate a secure API key for the dashboard management
+    openssl rand -hex 32
+
+    # Edit .env.admin with the generated key and actual secret values (DO NOT COMMIT)
     ```
 4.  Run the development server:
     ```bash

--- a/services/admin-dashboard/src/app/api/secrets/route.ts
+++ b/services/admin-dashboard/src/app/api/secrets/route.ts
@@ -50,6 +50,17 @@ function escapeEnvValue(rawValue: unknown) {
 }
 
 export async function POST(req: Request) {
+  // --- Security: API Key Authentication ---
+  const apiKeyHeader = req.headers.get("X-Admin-API-Key");
+  const expectedApiKey = process.env.ADMIN_DASHBOARD_API_KEY;
+
+  if (!expectedApiKey || apiKeyHeader !== expectedApiKey) {
+    return NextResponse.json(
+      { success: false, error: "Unauthorized: Invalid or missing X-Admin-API-Key" },
+      { status: 401 }
+    );
+  }
+
   try {
     let data: unknown;
     try {

--- a/services/admin-dashboard/src/app/settings/page.tsx
+++ b/services/admin-dashboard/src/app/settings/page.tsx
@@ -36,6 +36,7 @@ export default function SettingsPage() {
     ADMIN_CHANGELLY_API_KEY: "",
     ADMIN_CHANGELLY_API_SECRET: ""
   });
+  const [adminApiKey, setAdminApiKey] = useState("");
   const [loading, setLoading] = useState(false);
   const [saved, setSaved] = useState(false);
 
@@ -44,11 +45,19 @@ export default function SettingsPage() {
   };
 
   const handleSave = async () => {
+    if (!adminApiKey) {
+      alert("Please provide the Admin Dashboard API Key.");
+      return;
+    }
+
     setLoading(true);
     try {
       const res = await fetch("/api/secrets", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "X-Admin-API-Key": adminApiKey
+        },
         body: JSON.stringify({ secrets })
       });
       if (res.ok) {
@@ -71,7 +80,18 @@ export default function SettingsPage() {
       </div>
       
       <section style={{ backgroundColor: 'white', padding: '2rem', borderRadius: '8px', boxShadow: '0 4px 6px rgba(0,0,0,0.05)', marginBottom: '2rem' }}>
-        <h3 style={{ marginTop: 0, color: '#D4A017', fontSize: '1.2rem', borderBottom: '1px solid #eee', paddingBottom: '0.5rem' }}>Institutional Secrets</h3>
+        <h3 style={{ marginTop: 0, color: '#D4A017', fontSize: '1.2rem', borderBottom: '1px solid #eee', paddingBottom: '0.5rem' }}>Authentication</h3>
+        <p style={{ fontSize: '0.9rem', color: '#666', marginBottom: '1.5rem' }}>Provide the management API key to authorize changes.</p>
+        <div style={{ marginBottom: '1.5rem' }}>
+          <SecretInput
+            label="Admin Dashboard API Key"
+            name="adminApiKey"
+            value={adminApiKey}
+            onChange={(e) => setAdminApiKey(e.target.value)}
+          />
+        </div>
+
+        <h3 style={{ marginTop: '2rem', color: '#D4A017', fontSize: '1.2rem', borderBottom: '1px solid #eee', paddingBottom: '0.5rem' }}>Institutional Secrets</h3>
         <p style={{ fontSize: '0.9rem', color: '#666', marginBottom: '1.5rem' }}>These secrets are required for automated deployments (NPM, PyPI, GCP) and exchange integrations.</p>
         
         <div style={{ display: 'grid', gap: '1rem' }}>

--- a/services/admin-dashboard/src/tests/auth.test.ts
+++ b/services/admin-dashboard/src/tests/auth.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { POST } from '../app/api/secrets/route';
+import { NextResponse } from 'next/server';
+
+// Mock fs and path
+vi.mock('fs', () => ({
+  default: {
+    writeFileSync: vi.fn(),
+    chmodSync: vi.fn(),
+  },
+}));
+
+describe('Admin Secrets API Auth', () => {
+  const mockApiKey = 'test-api-key';
+
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.ADMIN_DASHBOARD_API_KEY = mockApiKey;
+  });
+
+  it('should return 401 if X-Admin-API-Key header is missing', async () => {
+    const req = new Request('http://localhost/api/secrets', {
+      method: 'POST',
+      body: JSON.stringify({ secrets: {} }),
+    });
+
+    const response = await POST(req);
+    expect(response.status).toBe(401);
+    const data = await response.json();
+    expect(data.error).toContain('Unauthorized');
+  });
+
+  it('should return 401 if X-Admin-API-Key header is incorrect', async () => {
+    const req = new Request('http://localhost/api/secrets', {
+      method: 'POST',
+      headers: {
+        'X-Admin-API-Key': 'wrong-key',
+      },
+      body: JSON.stringify({ secrets: {} }),
+    });
+
+    const response = await POST(req);
+    expect(response.status).toBe(401);
+  });
+
+  it('should return 200 if X-Admin-API-Key header is correct', async () => {
+    const req = new Request('http://localhost/api/secrets', {
+      method: 'POST',
+      headers: {
+        'X-Admin-API-Key': mockApiKey,
+      },
+      body: JSON.stringify({ secrets: {} }),
+    });
+
+    const response = await POST(req);
+    // It might return 400 if the body is empty/invalid, but it should pass the 401 check
+    expect(response.status).not.toBe(401);
+  });
+});


### PR DESCRIPTION
This PR implements API key authentication for the sensitive secrets management interface in the admin-dashboard. It ensures that only authorized users providing a valid `ADMIN_DASHBOARD_API_KEY` can modify institutional secrets like GitHub PATs, NPM tokens, and GCP credentials.

Key changes:
- API Route: Added a check for the `X-Admin-API-Key` header in `services/admin-dashboard/src/app/api/secrets/route.ts`.
- UI: Added a password-masked input for the API key in `services/admin-dashboard/src/app/settings/page.tsx`.
- Config: Added `ADMIN_DASHBOARD_API_KEY` to `.env.schema` and `.env.admin.example`.
- Docs: Updated `services/admin-dashboard/README.md` with setup instructions.
- Tests: Added `services/admin-dashboard/src/tests/auth.test.ts` to verify the new auth logic.

---
*PR created automatically by Jules for task [9555814418133875905](https://jules.google.com/task/9555814418133875905) started by @botshelomokoka*