### PR TITLE
Add repo ownership boundary document

### DIFF
--- a/REPO_OWNERSHIP.md
+++ b/REPO_OWNERSHIP.md
@@ -1,0 +1,28 @@
+# Repo ownership
+
+## Purpose
+
+`conxius-platform` is the composition, runtime, and integration harness repo for the Conxian builder platform.
+
+## This repo owns
+
+- local ecosystem composition
+- integration harnesses
+- runtime wiring
+- observability and validation environments
+- orchestrated developer workflows across strategic repos
+
+## This repo does not own
+
+- canonical shared-core logic
+- canonical adapter implementations
+- wallet UX ownership
+- portfolio-wide strategy ownership
+
+## Boundary rule
+
+This repo should compose strategic repos rather than become the hidden home of business logic that belongs in `lib-conxian-core`, `conxian-gateway`, or `conxius-enclave-sdk`.
+
+## Strategic role
+
+Primary strategic repo, with a composition/runtime scope.


### PR DESCRIPTION
## What this adds

- `REPO_OWNERSHIP.md`

## Why

`conxius-platform` needs a clear composition/runtime identity so it does not become a catch-all repository.

## What it clarifies

- composition and runtime ownership
- non-goals around canonical logic ownership

## Intended follow-up

- use this when narrowing platform scope and during future cleanup work