### PR TITLE
Normalize nested platform security and support contacts

### DIFF
--- a/services/admin-dashboard/CONTRIBUTING.md
+++ b/services/admin-dashboard/CONTRIBUTING.md
@@ -50,4 +50,4 @@ pnpm --filter ./services/elizaos-plugin-conxian test
 
 ## Contact
 
-For any questions or feedback, please reach out via GitHub Issues or contact the team at dev@conxian.com.
+For questions or feedback, use GitHub Issues or contact [support@conxian-labs.com](mailto:support@conxian-labs.com).

--- a/services/admin-dashboard/SECURITY.md
+++ b/services/admin-dashboard/SECURITY.md
@@ -4,22 +4,22 @@
 
 Only the latest release of the Conxian monorepo and its constituent services are supported for security updates.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| v0.x    | :white_check_mark: |
-| < v0.x  | :x:                |
+| Version | Supported |
+| ------- | --------- |
+| v0.x | ✅ |
+| < v0.x | ❌ |
 
 ## Reporting a Vulnerability
 
-We take the security of Conxian very seriously. If you believe you've found a security vulnerability in one of our repositories, please report it to us immediately.
+We take the security of Conxian seriously.
 
 **Do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please send an email to [security@conxian.com](mailto:security@conxian.com) with the following information:
+Instead, use GitHub private vulnerability reporting where available or email [security@conxian-labs.com](mailto:security@conxian-labs.com) with:
 
-- The repository and branch affected
-- A description of the vulnerability and its potential impact
-- Steps to reproduce the issue
-- Any suggested fixes or mitigations
+- the repository and branch affected
+- a description of the issue and its potential impact
+- steps to reproduce
+- any suggested fixes or mitigations
 
-We will acknowledge receipt of your report and provide a timeline for addressing the issue. We appreciate your help in keeping Conxian secure.
+We will acknowledge receipt and coordinate remediation privately.

--- a/services/admin-pulse-bos/SECURITY.md
+++ b/services/admin-pulse-bos/SECURITY.md
@@ -4,22 +4,22 @@
 
 Only the latest release of the Conxian monorepo and its constituent services are supported for security updates.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| v0.x    | :white_check_mark: |
-| < v0.x  | :x:                |
+| Version | Supported |
+| ------- | --------- |
+| v0.x | ✅ |
+| < v0.x | ❌ |
 
 ## Reporting a Vulnerability
 
-We take the security of Conxian very seriously. If you believe you've found a security vulnerability in one of our repositories, please report it to us immediately.
+We take the security of Conxian seriously.
 
 **Do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please send an email to [security@conxian.com](mailto:security@conxian.com) with the following information:
+Instead, use GitHub private vulnerability reporting where available or email [security@conxian-labs.com](mailto:security@conxian-labs.com) with:
 
-- The repository and branch affected
-- A description of the vulnerability and its potential impact
-- Steps to reproduce the issue
-- Any suggested fixes or mitigations
+- the repository and branch affected
+- a description of the issue and its potential impact
+- steps to reproduce
+- any suggested fixes or mitigations
 
-We will acknowledge receipt of your report and provide a timeline for addressing the issue. We appreciate your help in keeping Conxian secure.
+We will acknowledge receipt and coordinate remediation privately.

--- a/services/elizaos-plugin-conxian/SECURITY.md
+++ b/services/elizaos-plugin-conxian/SECURITY.md
@@ -4,22 +4,22 @@
 
 Only the latest release of the Conxian monorepo and its constituent services are supported for security updates.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| v0.x    | :white_check_mark: |
-| < v0.x  | :x:                |
+| Version | Supported |
+| ------- | --------- |
+| v0.x | ✅ |
+| < v0.x | ❌ |
 
 ## Reporting a Vulnerability
 
-We take the security of Conxian very seriously. If you believe you've found a security vulnerability in one of our repositories, please report it to us immediately.
+We take the security of Conxian seriously.
 
 **Do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please send an email to [security@conxian.com](mailto:security@conxian.com) with the following information:
+Instead, use GitHub private vulnerability reporting where available or email [security@conxian-labs.com](mailto:security@conxian-labs.com) with:
 
-- The repository and branch affected
-- A description of the vulnerability and its potential impact
-- Steps to reproduce the issue
-- Any suggested fixes or mitigations
+- the repository and branch affected
+- a description of the issue and its potential impact
+- steps to reproduce
+- any suggested fixes or mitigations
 
-We will acknowledge receipt of your report and provide a timeline for addressing the issue. We appreciate your help in keeping Conxian secure.
+We will acknowledge receipt and coordinate remediation privately.


### PR DESCRIPTION
## What changed
- standardized nested admin-service security policies on `security@conxian-labs.com`
- replaced stale `dev@conxian.com` support routing in nested contributing guidance

## Why
These files were still exposing legacy public contact domains after the org-wide standardization pass.