### PR TITLE
Security Hardening: PII and Bitcoin-native Redaction for Support Integration

### DIFF
--- a/services/admin-dashboard/src/lib/support/imap-worker.ts
+++ b/services/admin-dashboard/src/lib/support/imap-worker.ts
@@ -73,7 +73,8 @@ export class ImapWorker {
           inReplyTo: parsed.inReplyTo,
         };
 
-        console.log(`[IMAP] Processing email from ${email.from}: ${email.subject}`);
+        const sanitizedSubjectForLog = this.scrubContent(email.subject);
+        console.log(`[IMAP] Processing email from ${email.from.split('@')[1] || 'unknown'}: ${sanitizedSubjectForLog}`);
 
         const result = await this.processEmail(email);
 
@@ -157,9 +158,20 @@ export class ImapWorker {
 
   private scrubContent(text: string): string {
     let scrubbed = text;
+    // PII Redaction
     scrubbed = scrubbed.replace(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g, '[REDACTED-EMAIL]');
-    scrubbed = scrubbed.replace(/\b[a-f0-9]{32,64}\b/gi, '[REDACTED-TOKEN]');
     scrubbed = scrubbed.replace(/\b(invoice|inv)-[a-z0-9-]+\b/gi, '[REDACTED-INVOICE]');
+
+    // Token & Secret Redaction (Hex/Base64 secrets)
+    scrubbed = scrubbed.replace(/\b[a-f0-9]{32,64}\b/gi, '[REDACTED-TOKEN]');
+
+    // Bitcoin-native Redaction
+    // Legacy (1, 3) and WIF (5, K, L)
+    scrubbed = scrubbed.replace(/\b[13][a-km-zA-HJ-NP-Z1-9]{25,34}\b/g, '[REDACTED-BTC-ADDR]');
+    scrubbed = scrubbed.replace(/\b[5KL][1-9A-HJ-NP-Za-km-z]{50,51}\b/g, '[REDACTED-BTC-KEY]');
+    // Bech32/SegWit (bc1)
+    scrubbed = scrubbed.replace(/\bbc1[a-z0-9]{39,59}\b/g, '[REDACTED-BTC-ADDR]');
+
     return scrubbed;
   }
 
@@ -215,6 +227,7 @@ export class ImapWorker {
 
   private async processEmail(email: SupportEmail): Promise<{ success: boolean; token: string }> {
     const token = this.generateTicketToken();
+    const sanitizedSubject = this.scrubContent(email.subject);
     const sanitizedBody = this.scrubContent(email.body).substring(0, 2000);
     const senderDomain = email.from.split('@')[1] || 'unknown';
 
@@ -263,7 +276,7 @@ ${sanitizedBody}
 
       const variables = {
         input: {
-          title: `[${token}] ${email.subject}`,
+          title: `[${token}] ${sanitizedSubject}`,
           description,
           teamId: this.teamId,
           labelIds,

--- a/services/admin-dashboard/src/tests/support.test.ts
+++ b/services/admin-dashboard/src/tests/support.test.ts
@@ -4,14 +4,20 @@ import { ImapWorker } from '../lib/support/imap-worker';
 describe('ImapWorker', () => {
   const worker = new ImapWorker();
 
-  it('should scrub sensitive content', () => {
-    const raw = 'Hello, my email is test@example.com and my secret is 1234567890abcdef1234567890abcdef. Please check invoice INV-123.';
+  it('should scrub sensitive content including Bitcoin data', () => {
+    const raw = 'Email: test@example.com, Token: 1234567890abcdef1234567890abcdef, Invoice: INV-123, BTC: 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa, WIF: 5Kb8kLf9zgWQioS6T6YUpX4G22h2f2EWDGWWB8fKSv3YfW23955, Bech32: bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh';
     const scrubbed = (worker as any).scrubContent(raw);
     expect(scrubbed).not.toContain('test@example.com');
     expect(scrubbed).not.toContain('1234567890abcdef1234567890abcdef');
+    expect(scrubbed).not.toContain('1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa');
+    expect(scrubbed).not.toContain('5Kb8kLf9zgWQioS6T6YUpX4G22h2f2EWDGWWB8fKSv3YfW23955');
+    expect(scrubbed).not.toContain('bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh');
+
     expect(scrubbed).toContain('[REDACTED-EMAIL]');
     expect(scrubbed).toContain('[REDACTED-TOKEN]');
     expect(scrubbed).toContain('[REDACTED-INVOICE]');
+    expect(scrubbed).toContain('[REDACTED-BTC-ADDR]');
+    expect(scrubbed).toContain('[REDACTED-BTC-KEY]');
   });
 
   it('should generate a valid ticket token', () => {


### PR DESCRIPTION
This PR implements a security-first remediation for the support email integration. 

Key changes:
1. **Bitcoin-aware Redaction**: The `scrubContent` utility in `ImapWorker` now recognizes and redacts Bitcoin Legacy (1, 3), Bech32 (bc1) addresses, and WIF private keys (5, K, L).
2. **Subject Sanitization**: Previously, email subjects were sent directly to Linear, potentially leaking PII in issue titles. Subjects are now scrubbed before being sent to external systems.
3. **Privacy-enhanced Logging**: Reduced PII in server logs by stripping the local part of sender email addresses and scrubbing subjects before logging.
4. **Verified Remediation**: Updated `support.test.ts` to cover the new redaction patterns.

These changes mitigate the risk of accidental exposure of financial credentials and PII through the support ticketing pipeline.

---
*PR created automatically by Jules for task [6475809149487980997](https://jules.google.com/task/6475809149487980997) started by @admin-conxian-labs*