### PR TITLE
P1: add platform secret scanning and track scope cleanup

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,25 @@
+name: Secret Scan
+
+on:
+  pull_request:
+    branches: [ main, staged, dev ]
+  push:
+    branches: [ main, staged, dev ]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: Secret Scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## What changed
- add repo-local `gitleaks` secret scanning workflow

## Why
The platform repo already has strong governance and CI coverage, but it was missing an explicit secret-scan workflow in `.github/workflows`.

## Follow-up tracked separately
- issue #825 covers the broader platform cleanup pass:
  - `.circleci/` legacy drift review
  - root-doc scope tightening
  - clearer issue routing / scope discipline
